### PR TITLE
P2P port

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -126,7 +126,7 @@ public:
         pchMessageStart[1] = 0xf1;
         pchMessageStart[2] = 0x04;
         pchMessageStart[3] = 0xfd;
-        nDefaultPort = 18181;
+        nDefaultPort = 18188;
         nPruneAfterHeight = 100000;
 
         genesis = CreateGenesisBlock(1384473600, 1397766, 0x1e0ffff0, 1, 100 * COIN);


### PR DESCRIPTION
18188 is used for P2P, 18181 is for RPC.  
Bitcoin Core has 'nDefaultPort = 8333;' which is P2P

Please check as Im unsure, this seemed to work on a local copy compiled from onsightit